### PR TITLE
fix: fixed slight visual bug on button's svg

### DIFF
--- a/src/assets/svg/ButtonSvg.jsx
+++ b/src/assets/svg/ButtonSvg.jsx
@@ -7,14 +7,14 @@ const ButtonSvg = (white) => (
       viewBox="0 0 21 44"
     >
       <path
-        fill={white ? "white" : ""}
+        fill={white ? "white" : "none"}
         stroke={white ? "white" : "url(#btn-left)"} // mentioned in ButtonGradient.jsx
         strokeWidth="2"
         d="M21,43.00005 L8.11111,43.00005 C4.18375,43.00005 1,39.58105 1,35.36365 L1,8.63637 C1,4.41892 4.18375,1 8.11111,1 L21,1"
       />
     </svg>
     <svg
-      className="absolute top-0 left-[1.3125rem] w-[calc(100%-2.625rem)]"
+      className="absolute top-0 left-[1.29rem] w-[calc(100%-2.5rem)]"
       height="44"
       viewBox="0 0 100 44"
       preserveAspectRatio="none"


### PR DESCRIPTION
the button had a thin line for on the left side (which ended up being a gap), and on the gradient version the left side was colored because the fill was not specified to "none"